### PR TITLE
Update VRED-VR-drawLines.py

### DIFF
--- a/VRED-VR-drawLines.py
+++ b/VRED-VR-drawLines.py
@@ -523,7 +523,7 @@ class DrawinVR():
            
     def createMenu(self):
         
-        self.tool = vrImmersiveUiService.createTool("Draw")
+        self.tool = vrImmersiveUiService.createTool("Tool_Draw")
         self.tool.setText("Draw")
         self.tool.setCheckable(True)
         #self.tool.setIcon(icon)
@@ -541,7 +541,7 @@ class DrawinVR():
         
         allTools = vrImmersiveUiService.getTools()
         for tool in allTools:
-            if tool.getIsInternal() == False and tool.getName() != self.tool.getName():
+            if tool.getIsInternal() == False and tool.getName() != self.tool.getName() and tool.getName()[:5] == 'Tool_':
                 tool.setChecked(False)
                 tool.signal().unchecked.emit(None)
         print("Draw Enabled")


### PR DESCRIPTION
Hi Simon,
Fixed the menu interchangeability issue second time: When the new menu button is pressed the already enabled button will be disabled automatically. Changed the name of the tool and added a new condition in the enable function to check the names of the tools starts with 'tools_'.